### PR TITLE
Support multiple memory regions/connections

### DIFF
--- a/GroundDBMemoryPool/src/include/rdma.hh
+++ b/GroundDBMemoryPool/src/include/rdma.hh
@@ -48,12 +48,13 @@ struct cm_con_data_t
 struct connection{
     struct ibv_cq *cq;                 /* CQ handle */
     struct ibv_qp *qp;                 /* QP handle */
-    int sock;                          /* TCP socket file descriptor */
+    int sock{-1};                      /* TCP socket file descriptor */
 };
 struct memory_region{
     std::vector<connection> conns;
     struct ibv_mr *mr;                 /* MR handle for buf */
     char *buf;                         /* memory buffer pointer, used for RDMA and send ops */
+    bool buf_exclusive;                /* whether buf is exclusive or not */
 };
 /* structure of system resources */
 struct resources

--- a/GroundDBMemoryPool/src/include/rdma.hh
+++ b/GroundDBMemoryPool/src/include/rdma.hh
@@ -8,6 +8,7 @@
 #include <endian.h>
 #include <byteswap.h>
 #include <getopt.h>
+#include <vector>
 
 #include <sys/time.h>
 #include <arpa/inet.h>
@@ -15,6 +16,9 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netdb.h>
+
+namespace mempool{
+
 /* poll CQ timeout in millisec (2 seconds) */
 #define MAX_POLL_CQ_TIMEOUT 2000
 #define VERIFIER "VERIFY_CONNECTION"
@@ -41,6 +45,16 @@ struct cm_con_data_t
     uint8_t gid[16]; /* gid */
 } __attribute__((packed));
 
+struct connection{
+    struct ibv_cq *cq;                 /* CQ handle */
+    struct ibv_qp *qp;                 /* QP handle */
+    int sock;                          /* TCP socket file descriptor */
+};
+struct memory_region{
+    std::vector<connection> conns;
+    struct ibv_mr *mr;                 /* MR handle for buf */
+    char *buf;                         /* memory buffer pointer, used for RDMA and send ops */
+};
 /* structure of system resources */
 struct resources
 {
@@ -51,13 +65,10 @@ struct resources
     struct cm_con_data_t remote_props; /* values to connect to remote side */
     struct ibv_context *ib_ctx;        /* device handle */
     struct ibv_pd *pd;                 /* PD handle */
-    struct ibv_cq *cq;                 /* CQ handle */
-    struct ibv_qp *qp;                 /* QP handle */
-    struct ibv_mr *mr;                 /* MR handle for buf */
-    char *buf;                         /* memory buffer pointer, used for RDMA and send
-ops */
-    int sock;                          /* TCP socket file descriptor */
+    std::vector<struct memory_region> memregs;
 };
+
+} // namespace mempool
 
 #ifdef SERVER
 #include <rdma_server.hh>

--- a/GroundDBMemoryPool/src/include/rdma.hh
+++ b/GroundDBMemoryPool/src/include/rdma.hh
@@ -54,7 +54,7 @@ struct memory_region{
     std::vector<connection> conns;
     struct ibv_mr *mr;                 /* MR handle for buf */
     char *buf;                         /* memory buffer pointer, used for RDMA and send ops */
-    bool buf_exclusive;                /* whether buf is exclusive or not */
+    bool isBufDeletableFlag;                /* whether buf is exclusive or not */
 };
 /* structure of system resources */
 struct resources

--- a/GroundDBMemoryPool/src/include/rdma_client.hh
+++ b/GroundDBMemoryPool/src/include/rdma_client.hh
@@ -12,12 +12,16 @@ struct resources *connectServer(
 
 int rdma_read(
     const struct resources *res, /* RDMA Connection resources */
+    struct memory_region *memreg,
+    struct connection *conn,
     char *buffer,                /* Local buffer to read into */
     const size_t size            /* number of bytes to read */
 );
 
 int rdma_write(
     struct resources *res, /* RDMA Connection resources */
+    struct memory_region *memreg,
+    struct connection *conn,
     const char *buffer,    /* Local buffer to write from */
     const size_t size      /* number of bytes to write */
 );

--- a/GroundDBMemoryPool/src/include/rdma_client.hh
+++ b/GroundDBMemoryPool/src/include/rdma_client.hh
@@ -1,4 +1,7 @@
 #pragma once
+
+namespace mempool{
+
 struct resources *connectServer(
     const char *server_name, /* server host name */
     const int tcp_port,      /* server TCP port */
@@ -18,3 +21,5 @@ int rdma_write(
     const char *buffer,    /* Local buffer to write from */
     const size_t size      /* number of bytes to write */
 );
+
+} // namespace mempool

--- a/GroundDBMemoryPool/src/include/rdma_server.hh
+++ b/GroundDBMemoryPool/src/include/rdma_server.hh
@@ -1,8 +1,12 @@
 #pragma once
 
+namespace mempool{
+
 struct resources* init_server(
     const int tcp_port,     /* server TCP port */
     const char *ib_devname, /* server device name. If NULL, client will use the first
                                found device */
     const int ib_port       /* server IB port */
 );
+
+} // namespace mempool

--- a/GroundDBMemoryPool/src/main_client.cc
+++ b/GroundDBMemoryPool/src/main_client.cc
@@ -1,7 +1,7 @@
 #include <memoryPool.hh>
 int main()
 {
-    connectServer(
+    mempool::connectServer(
         "127.0.0.1",
         122189,
         NULL,

--- a/GroundDBMemoryPool/src/main_server.cc
+++ b/GroundDBMemoryPool/src/main_server.cc
@@ -1,7 +1,7 @@
 #include <memoryPool.hh>
 int main()
 {
-    init_server(
+    mempool::init_server(
         122189,
         NULL,
         1);

--- a/GroundDBMemoryPool/src/rdma/rdma_client/connect.cc
+++ b/GroundDBMemoryPool/src/rdma/rdma_client/connect.cc
@@ -27,17 +27,19 @@ struct resources *connectServer(
         fprintf(stderr, "failed to create resources\n");
         return NULL;
     }
-    if (register_mr(res)){
+    struct memory_region *memreg = nullptr;
+    if (register_mr(memreg, res)){
         fprintf(stderr, "failed to register memory regions\n");
         return NULL;
     }
-    if (connect_qp(res, &res->memregs[0], server_name, tcp_port, -1, ib_port))
+    struct connection *conn = nullptr;
+    if (connect_qp(conn, res, memreg, server_name, tcp_port, -1, ib_port))
     {
         fprintf(stderr, "failed to connect QPs\n");
         return NULL;
     }
     // Following lines are only for simulation and will be removed in the future.
-    if (post_receive(res, &res->memregs[0], &res->memregs[0].conns[0]))
+    if (post_receive(res, memreg, conn))
     {
         fprintf(stderr, "failed to post RR\n");
         return NULL;

--- a/GroundDBMemoryPool/src/rdma/rdma_client/connect.cc
+++ b/GroundDBMemoryPool/src/rdma/rdma_client/connect.cc
@@ -1,5 +1,8 @@
 #include <rdma.hh>
 #include "../util.h"
+
+namespace mempool{
+
 struct resources *connectServer(
     const char *server_name, /* server host name */
     const int tcp_port,      /* server TCP port */
@@ -8,7 +11,7 @@ struct resources *connectServer(
     const int ib_port        /* server IB port */
 )
 {
-    struct resources *res = (struct resources *)malloc(sizeof(struct resources));
+    struct resources *res = new struct resources();
     if (!res)
     {
         fprintf(stderr, "failed to malloc struct resource\n");
@@ -31,13 +34,13 @@ struct resources *connectServer(
         fprintf(stderr, "failed to connect QPs\n");
         return NULL;
     }
-    if (poll_completion(res))
+    if (poll_completion(res, &(res->memregs[0].conns[0])))
     {
         fprintf(stderr, "poll completion failed\n");
         return NULL;
     }
     // Verify connection by matching the string VERIFIER sent by the server
-    if (strcmp(res->buf, VERIFIER))
+    if (strcmp(res->memregs[0].buf, VERIFIER))
     {
         fprintf(stderr, "failed to verify connection\n");
         return NULL;
@@ -45,3 +48,5 @@ struct resources *connectServer(
     fprintf(stdout, "Connection verified\n");
     return res;
 }
+
+} // namespace mempool

--- a/GroundDBMemoryPool/src/rdma/rdma_client/read.cc
+++ b/GroundDBMemoryPool/src/rdma/rdma_client/read.cc
@@ -1,26 +1,30 @@
 #include <rdma.hh>
 #include "../util.h"
 
+namespace mempool{
+
 int rdma_read(
     const struct resources *res, /* RDMA Connection resources */
     char *buffer,                /* Local buffer to read into */
     const size_t size            /* number of bytes to read */
 )
 {
-    if (post_send(res, IBV_WR_RDMA_READ))
+    if (post_send(res, &res->memregs[0], &res->memregs[0].conns[0], IBV_WR_RDMA_READ))
     {
         fprintf(stderr, "failed to post SR\n");
         return 1;
     }
 
-    if (poll_completion(res))
+    if (poll_completion(res, &res->memregs[0].conns[0]))
     {
         fprintf(stderr, "poll completion failed\n");
         return 1;
     }
     memcpy(
         buffer,
-        res->buf,
+        res->memregs[0].buf,
         size);
     return 0;
 }
+
+} // namespace mempool

--- a/GroundDBMemoryPool/src/rdma/rdma_client/read.cc
+++ b/GroundDBMemoryPool/src/rdma/rdma_client/read.cc
@@ -5,24 +5,26 @@ namespace mempool{
 
 int rdma_read(
     const struct resources *res, /* RDMA Connection resources */
+    struct memory_region *memreg,
+    struct connection *conn,
     char *buffer,                /* Local buffer to read into */
     const size_t size            /* number of bytes to read */
 )
 {
-    if (post_send(res, &res->memregs[0], &res->memregs[0].conns[0], IBV_WR_RDMA_READ))
+    if (post_send(res, memreg, conn, IBV_WR_RDMA_READ))
     {
         fprintf(stderr, "failed to post SR\n");
         return 1;
     }
 
-    if (poll_completion(res, &res->memregs[0].conns[0]))
+    if (poll_completion(res, conn))
     {
         fprintf(stderr, "poll completion failed\n");
         return 1;
     }
     memcpy(
         buffer,
-        res->memregs[0].buf,
+        memreg->buf,
         size);
     return 0;
 }

--- a/GroundDBMemoryPool/src/rdma/rdma_client/write.cc
+++ b/GroundDBMemoryPool/src/rdma/rdma_client/write.cc
@@ -1,6 +1,8 @@
 #include <rdma.hh>
 #include "../util.h"
 
+namespace mempool{
+
 int rdma_write(
     struct resources *res, /* RDMA Connection resources */
     const char *buffer,    /* Local buffer to write from */
@@ -8,17 +10,19 @@ int rdma_write(
 )
 {
     // Attempt to perform rdma write
-    memcpy(res->buf, buffer, size);
-    if (post_send(res, IBV_WR_RDMA_WRITE))
+    memcpy(res->memregs[0].buf, buffer, size);
+    if (post_send(res, &res->memregs[0], &res->memregs[0].conns[0], IBV_WR_RDMA_WRITE))
     {
         fprintf(stderr, "failed to post SR\n");
         return 1;
     }
 
-    if (poll_completion(res))
+    if (poll_completion(res, &res->memregs[0].conns[0]))
     {
         fprintf(stderr, "poll completion failed\n");
         return 1;
     }
     return 0;
 }
+
+} // namespace mempool

--- a/GroundDBMemoryPool/src/rdma/rdma_client/write.cc
+++ b/GroundDBMemoryPool/src/rdma/rdma_client/write.cc
@@ -5,19 +5,21 @@ namespace mempool{
 
 int rdma_write(
     struct resources *res, /* RDMA Connection resources */
+    struct memory_region *memreg,
+    struct connection *conn,
     const char *buffer,    /* Local buffer to write from */
     const size_t size      /* number of bytes to write */
 )
 {
     // Attempt to perform rdma write
-    memcpy(res->memregs[0].buf, buffer, size);
-    if (post_send(res, &res->memregs[0], &res->memregs[0].conns[0], IBV_WR_RDMA_WRITE))
+    memcpy(memreg->buf, buffer, size);
+    if (post_send(res, memreg, conn, IBV_WR_RDMA_WRITE))
     {
         fprintf(stderr, "failed to post SR\n");
         return 1;
     }
 
-    if (poll_completion(res, &res->memregs[0].conns[0]))
+    if (poll_completion(res, conn))
     {
         fprintf(stderr, "poll completion failed\n");
         return 1;

--- a/GroundDBMemoryPool/src/rdma/rdma_server/init_server.cc
+++ b/GroundDBMemoryPool/src/rdma/rdma_server/init_server.cc
@@ -19,23 +19,31 @@ struct resources* init_server(const int tcp_port,     /* server TCP port */
     if (resources_create(
             res,
             NULL,
-            tcp_port,
             ib_devname,
             ib_port))
     {
         fprintf(stderr, "failed to create resources\n");
         exit(1);
     }
-    if (connect_qp(res, NULL, -1, ib_port))
+    if (register_mr(res)){
+        fprintf(stderr, "failed to register memory regions\n");
+        return NULL;
+    }
+    if (connect_qp(res, &res->memregs[0], NULL, tcp_port, -1, ib_port))
     {
         fprintf(stderr, "failed to connect QPs\n");
         exit(1);
     }
+    // Following lines are only for simulation and will be removed in the future.
+    sleep(1);
+    strcpy(res->memregs[0].buf, VERIFIER);
+    fprintf(stdout, "going to send the message: '%s'\n", res->memregs[0].buf);
     if (post_send(res, &res->memregs[0], &res->memregs[0].conns[0], IBV_WR_SEND))
     {
         fprintf(stderr, "failed to post SR\n");
         exit(1);
     }
+    // Remove until here
     return res;
 }
 

--- a/GroundDBMemoryPool/src/rdma/rdma_server/init_server.cc
+++ b/GroundDBMemoryPool/src/rdma/rdma_server/init_server.cc
@@ -1,12 +1,15 @@
 #include <rdma.hh>
 #include "../util.h"
+
+namespace mempool {
+
 struct resources* init_server(const int tcp_port,     /* server TCP port */
                  const char *ib_devname, /* server device name. If NULL, client will use the first
                                             found device */
                  const int ib_port       /* server IB port */
 )
 {
-    struct resources *res = (struct resources *)malloc(sizeof(struct resources));
+    struct resources *res = new struct resources();
     if (!res)
     {
         fprintf(stderr, "failed to malloc struct resource\n");
@@ -28,10 +31,12 @@ struct resources* init_server(const int tcp_port,     /* server TCP port */
         fprintf(stderr, "failed to connect QPs\n");
         exit(1);
     }
-    if (post_send(res, IBV_WR_SEND))
+    if (post_send(res, &res->memregs[0], &res->memregs[0].conns[0], IBV_WR_SEND))
     {
         fprintf(stderr, "failed to post SR\n");
         exit(1);
     }
     return res;
 }
+
+} // namespace mempool

--- a/GroundDBMemoryPool/src/rdma/rdma_server/init_server.cc
+++ b/GroundDBMemoryPool/src/rdma/rdma_server/init_server.cc
@@ -25,20 +25,22 @@ struct resources* init_server(const int tcp_port,     /* server TCP port */
         fprintf(stderr, "failed to create resources\n");
         exit(1);
     }
-    if (register_mr(res)){
+    struct memory_region *memreg = nullptr;
+    if (register_mr(memreg, res)){
         fprintf(stderr, "failed to register memory regions\n");
         return NULL;
     }
-    if (connect_qp(res, &res->memregs[0], NULL, tcp_port, -1, ib_port))
+    struct connection *conn = nullptr;
+    if (connect_qp(conn, res, memreg, NULL, tcp_port, -1, ib_port))
     {
         fprintf(stderr, "failed to connect QPs\n");
         exit(1);
     }
     // Following lines are only for simulation and will be removed in the future.
     sleep(1);
-    strcpy(res->memregs[0].buf, VERIFIER);
-    fprintf(stdout, "going to send the message: '%s'\n", res->memregs[0].buf);
-    if (post_send(res, &res->memregs[0], &res->memregs[0].conns[0], IBV_WR_SEND))
+    strcpy(memreg->buf, VERIFIER);
+    fprintf(stdout, "going to send the message: '%s'\n", memreg->buf);
+    if (post_send(res, memreg, conn, IBV_WR_SEND))
     {
         fprintf(stderr, "failed to post SR\n");
         exit(1);

--- a/GroundDBMemoryPool/src/rdma/util.cc
+++ b/GroundDBMemoryPool/src/rdma/util.cc
@@ -161,7 +161,7 @@ End of socket operations
  * poll the queue until MAX_POLL_CQ_TIMEOUT milliseconds have passed.
  *
  ******************************************************************************/
-int poll_completion(const struct resources *res, const struct connection* conn)
+int poll_completion(const struct connection* conn)
 {
     struct ibv_wc wc;
     unsigned long start_time_msec;
@@ -282,7 +282,7 @@ int post_send(const struct resources *res, const struct memory_region *memreg, c
  * Description
  *
  ******************************************************************************/
-int post_receive(const struct resources *res, const struct memory_region *memreg, const struct connection *conn)
+int post_receive(const struct memory_region *memreg, const struct connection *conn)
 {
     struct ibv_recv_wr rr;
     struct ibv_sge sge;
@@ -435,24 +435,23 @@ resources_create_exit:
  * Description
  * Register a new memory region.
  ******************************************************************************/
-int register_mr(struct resources *res, char* buf, size_t size){
+int register_mr(struct resources *res, const char* buf, size_t size){
     int mr_flags = 0;
     int rc = 0;
     res->memregs.emplace_back();
     auto& memreg = res->memregs.back();
     /* allocate the memory buffer that will hold the data */
     if (buf == nullptr){
-        memreg.buf = (char *)malloc(size);
+        memreg.buf = new char[size]();
         if (!memreg.buf){
             fprintf(stderr, "failed to malloc %Zu bytes to memory buffer\n", size);
             rc = 1;
             goto register_mr_exit;
         }
-        memset(memreg.buf, 0, size);
         memreg.buf_exclusive = true;
     }
     else {
-        memreg.buf = buf;
+        memreg.buf = (char*)buf;
         memreg.buf_exclusive = false;
     }
     /* register the memory buffer */

--- a/GroundDBMemoryPool/src/rdma/util.cc
+++ b/GroundDBMemoryPool/src/rdma/util.cc
@@ -161,6 +161,9 @@ End of socket operations
  * poll the queue until MAX_POLL_CQ_TIMEOUT milliseconds have passed.
  *
  ******************************************************************************/
+int poll_completion(const struct resources *res, const struct connection* conn){
+    return poll_completion(conn);
+}
 int poll_completion(const struct connection* conn)
 {
     struct ibv_wc wc;
@@ -282,6 +285,9 @@ int post_send(const struct resources *res, const struct memory_region *memreg, c
  * Description
  *
  ******************************************************************************/
+int post_receive(const struct resources *res, const struct memory_region *memregs, const struct connection *conn){
+    return post_receive(memregs, conn);
+}
 int post_receive(const struct memory_region *memreg, const struct connection *conn)
 {
     struct ibv_recv_wr rr;

--- a/GroundDBMemoryPool/src/rdma/util.cc
+++ b/GroundDBMemoryPool/src/rdma/util.cc
@@ -454,11 +454,11 @@ int register_mr(struct resources *res, const char* buf, size_t size){
             rc = 1;
             goto register_mr_exit;
         }
-        memreg.buf_exclusive = true;
+        memreg.isBufDeletableFlag = true;
     }
     else {
         memreg.buf = (char*)buf;
-        memreg.buf_exclusive = false;
+        memreg.isBufDeletableFlag = false;
     }
     /* register the memory buffer */
     mr_flags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_WRITE;
@@ -480,7 +480,7 @@ register_mr_exit:
             ibv_dereg_mr(memreg.mr);
             memreg.mr = NULL;
         }
-        if (memreg.buf && memreg.buf_exclusive)
+        if (memreg.buf && memreg.isBufDeletableFlag)
         {
             free(memreg.buf);
             memreg.buf = NULL;
@@ -825,7 +825,7 @@ int resources_destroy(struct resources *res)
                 fprintf(stderr, "failed to deregister MR\n");
                 rc = 1;
             }
-        if (memreg.buf && memreg.buf_exclusive)
+        if (memreg.buf && memreg.isBufDeletableFlag)
             free(memreg.buf);
     }
     if (res->pd)

--- a/GroundDBMemoryPool/src/rdma/util.h
+++ b/GroundDBMemoryPool/src/rdma/util.h
@@ -9,10 +9,10 @@ int post_receive(const struct resources *res, const struct memory_region *memreg
 int resources_create(
     struct resources *res,
     const char *serverName,
-    const int tcpPort,
     const char *ibDevName,
     const int ibPort);
-int connect_qp(struct resources *res, const char *serverName, const int gid_idx, const int ibPort);
+int register_mr(struct resources *res, char* buf = nullptr, size_t size = BUFFER_SIZE);
+int connect_qp(struct resources *res, struct memory_region *memreg, const char *serverName, const int tcpPort, const int gid_idx, const int ibPort);
 int resources_destroy(struct resources *res);
 
 } // namespace mempool

--- a/GroundDBMemoryPool/src/rdma/util.h
+++ b/GroundDBMemoryPool/src/rdma/util.h
@@ -13,8 +13,8 @@ int resources_create(
     const char *serverName,
     const char *ibDevName,
     const int ibPort);
-int register_mr(struct resources *res, const char* buf = nullptr, size_t size = BUFFER_SIZE);
-int connect_qp(struct resources *res, struct memory_region *memreg, const char *serverName, const int tcpPort, const int gid_idx, const int ibPort);
+int register_mr(struct memory_region *&memreg, struct resources *res, const char* buf = nullptr, size_t size = BUFFER_SIZE);
+int connect_qp(struct connection *&conn, struct resources *res, struct memory_region *memreg, const char *serverName, const int tcpPort, const int gid_idx, const int ibPort);
 int resources_destroy(struct resources *res);
 
 } // namespace mempool

--- a/GroundDBMemoryPool/src/rdma/util.h
+++ b/GroundDBMemoryPool/src/rdma/util.h
@@ -4,14 +4,10 @@ namespace mempool{
 
 int sock_connect(const char *serverName, int port);
 int poll_completion(const struct connection* conn);
-int poll_completion(const struct resources *res, const struct connection* conn){
-    return poll_completion(conn);
-}
+int poll_completion(const struct resources *res, const struct connection* conn);
 int post_send(const struct resources *res, const struct memory_region *memregs, const struct connection *conn, const enum ibv_wr_opcode opcode);
 int post_receive(const struct memory_region *memregs, const struct connection *conn);
-int post_receive(const struct resources *res, const struct memory_region *memregs, const struct connection *conn){
-    return post_receive(memregs, conn);
-}
+int post_receive(const struct resources *res, const struct memory_region *memregs, const struct connection *conn);
 int resources_create(
     struct resources *res,
     const char *serverName,

--- a/GroundDBMemoryPool/src/rdma/util.h
+++ b/GroundDBMemoryPool/src/rdma/util.h
@@ -1,9 +1,11 @@
 #pragma once
 
+namespace mempool{
+
 int sock_connect(const char *serverName, int port);
-int poll_completion(const struct resources *res);
-int post_send(const struct resources *res, const enum ibv_wr_opcode opcode);
-int post_receive(const struct resources *res);
+int poll_completion(const struct resources *res, const struct connection* conn);
+int post_send(const struct resources *res, const struct memory_region *memregs, const struct connection *conn, const enum ibv_wr_opcode opcode);
+int post_receive(const struct resources *res, const struct memory_region *memregs, const struct connection *conn);
 int resources_create(
     struct resources *res,
     const char *serverName,
@@ -12,3 +14,5 @@ int resources_create(
     const int ibPort);
 int connect_qp(struct resources *res, const char *serverName, const int gid_idx, const int ibPort);
 int resources_destroy(struct resources *res);
+
+} // namespace mempool

--- a/GroundDBMemoryPool/src/rdma/util.h
+++ b/GroundDBMemoryPool/src/rdma/util.h
@@ -3,15 +3,21 @@
 namespace mempool{
 
 int sock_connect(const char *serverName, int port);
-int poll_completion(const struct resources *res, const struct connection* conn);
+int poll_completion(const struct connection* conn);
+int poll_completion(const struct resources *res, const struct connection* conn){
+    return poll_completion(conn);
+}
 int post_send(const struct resources *res, const struct memory_region *memregs, const struct connection *conn, const enum ibv_wr_opcode opcode);
-int post_receive(const struct resources *res, const struct memory_region *memregs, const struct connection *conn);
+int post_receive(const struct memory_region *memregs, const struct connection *conn);
+int post_receive(const struct resources *res, const struct memory_region *memregs, const struct connection *conn){
+    return post_receive(memregs, conn);
+}
 int resources_create(
     struct resources *res,
     const char *serverName,
     const char *ibDevName,
     const int ibPort);
-int register_mr(struct resources *res, char* buf = nullptr, size_t size = BUFFER_SIZE);
+int register_mr(struct resources *res, const char* buf = nullptr, size_t size = BUFFER_SIZE);
 int connect_qp(struct resources *res, struct memory_region *memreg, const char *serverName, const int tcpPort, const int gid_idx, const int ibPort);
 int resources_destroy(struct resources *res);
 


### PR DESCRIPTION
Each node still uses one `resources` to manage RDMA now.
Following are the changes:
- Each `resources` contains multiple `memory_region` to manage different memory segments separately and to enable `allocate_page_array`.
- Each `memory region` contains multiple `connection` so that the memory pool can be accessed by multiple clients.